### PR TITLE
Implement pawn promotion

### DIFF
--- a/dist/board.js
+++ b/dist/board.js
@@ -69,6 +69,10 @@ class Board {
             this.normalMove(move);
             this.removePiece(move.from.rank, move.to.file);
         }
+        else if (move.promotion) {
+            this.normalMove(move);
+            this.updatePiece(move.to.rank, move.to.file, move.promotion);
+        }
         else {
             this.normalMove(move);
         }
@@ -78,6 +82,9 @@ class Board {
             throw "move.piece should be defined";
         this.board[move.from.rank][move.from.file] = ".";
         this.board[move.to.rank][move.to.file] = move.piece;
+    }
+    updatePiece(rank, file, pieceCode) {
+        this.board[rank][file] = pieceCode;
     }
     removePiece(rank, file) {
         this.board[rank][file] = ".";

--- a/dist/move.js
+++ b/dist/move.js
@@ -65,6 +65,10 @@ class Move {
         const to = (0, utils_1.convertRankFile)(this.to.rank, this.to.file);
         lan += to;
         san += to;
+        if (this.promotion) {
+            lan += `=${this.promotion}`;
+            san += `=${this.promotion}`;
+        }
         if (this.checkmate) {
             lan += "#";
             san += "#";
@@ -80,6 +84,9 @@ class Move {
         let uci = "";
         uci += (0, utils_1.convertRankFile)(this.from.rank, this.from.file);
         uci += (0, utils_1.convertRankFile)(this.to.rank, this.to.file);
+        if (this.promotion) {
+            uci += this.promotion.toLowerCase();
+        }
         this.uci = uci;
     }
     sanAddFromFile() {

--- a/dist/piece.js
+++ b/dist/piece.js
@@ -118,7 +118,11 @@ class Pawn extends Piece {
         else {
             target = [this.rank + 1, this.file];
         }
-        if (this.inBoundaries(...target) && this.panelEmpty(...target)) {
+        if ((this.faction === "w" && target[0] === 0) ||
+            (this.faction === "b" && target[0] === 7)) {
+            this.checkPromotion(...target);
+        }
+        else if (this.inBoundaries(...target) && this.panelEmpty(...target)) {
             this.validateMove(...target);
         }
     }
@@ -138,7 +142,13 @@ class Pawn extends Piece {
         }
         for (let i = 0; i < targets.length; i++) {
             if (this.inBoundaries(...targets[i]) && this.canCapture(...targets[i])) {
-                this.validateMove(...targets[i]);
+                if ((this.faction === "w" && targets[i][0] === 0) ||
+                    (this.faction === "b" && targets[i][0] === 7)) {
+                    this.checkPromotion(...targets[i]);
+                }
+                else {
+                    this.validateMove(...targets[i]);
+                }
             }
         }
     }
@@ -155,6 +165,18 @@ class Pawn extends Piece {
                 move.enpassant = true;
                 this.checkSimulation(move);
             }
+        }
+    }
+    checkPromotion(rank, file) {
+        const promoteOption = ["Q", "R", "B", "N"];
+        for (let i = 0; i < 4; i++) {
+            const move = this.createMove(rank, file);
+            if (!this.panelEmpty(rank, file)) {
+                move.capture = true;
+                move.capturedPiece = this.boardRef.get(rank, file);
+            }
+            move.promotion = promoteOption[i];
+            this.checkSimulation(move);
         }
     }
 }

--- a/dist/player.js
+++ b/dist/player.js
@@ -83,13 +83,38 @@ class Player {
             return;
         }
         const [fr, ff] = [move.from.rank, move.from.file];
-        for (const piece of this.pieces) {
+        for (let i = 0; i < this.pieces.length; i++) {
+            const piece = this.pieces[i];
             if (piece.rank === fr && piece.file === ff) {
                 piece.move(move);
+                if (move.promotion) {
+                    const newPiece = this.createPromotionPiece(move);
+                    this.pieces[i] = newPiece;
+                }
                 return;
             }
         }
         throw "can't find piece from that rank and file";
+    }
+    createPromotionPiece(move) {
+        if (!move.promotion || !move.faction)
+            throw "move should have promotion and faction prop!";
+        const args = [
+            move.faction,
+            move.to.rank,
+            move.to.file,
+            this.chessRef,
+        ];
+        switch (move.promotion) {
+            case "Q":
+                return new piece_1.Queen(...args);
+            case "R":
+                return new piece_1.Rook(...args);
+            case "B":
+                return new piece_1.Bishop(...args);
+            case "N":
+                return new piece_1.Knight(...args);
+        }
     }
     castle(code) {
         let kingMove, rookMove;

--- a/src/board.ts
+++ b/src/board.ts
@@ -72,6 +72,9 @@ export default class Board {
     } else if (move.enpassant) {
       this.normalMove(move);
       this.removePiece(move.from.rank, move.to.file);
+    } else if (move.promotion) {
+      this.normalMove(move);
+      this.updatePiece(move.to.rank, move.to.file, move.promotion);
     } else {
       this.normalMove(move);
     }
@@ -81,6 +84,10 @@ export default class Board {
     if (!move.piece) throw "move.piece should be defined";
     this.board[move.from.rank][move.from.file] = ".";
     this.board[move.to.rank][move.to.file] = move.piece;
+  }
+
+  updatePiece(rank: number, file: number, pieceCode: string) {
+    this.board[rank][file] = pieceCode;
   }
 
   removePiece(rank: number, file: number) {

--- a/src/move.ts
+++ b/src/move.ts
@@ -91,6 +91,10 @@ export default class Move {
     const to = convertRankFile(this.to.rank, this.to.file);
     lan += to;
     san += to;
+    if (this.promotion) {
+      lan += `=${this.promotion}`;
+      san += `=${this.promotion}`;
+    }
     if (this.checkmate) {
       lan += "#";
       san += "#";
@@ -106,6 +110,9 @@ export default class Move {
     let uci = "";
     uci += convertRankFile(this.from.rank, this.from.file);
     uci += convertRankFile(this.to.rank, this.to.file);
+    if (this.promotion) {
+      uci += this.promotion.toLowerCase();
+    }
     this.uci = uci;
   }
 

--- a/src/move.ts
+++ b/src/move.ts
@@ -1,5 +1,5 @@
 import { convertRankFile } from "./utils";
-import { Faction, CastleCode } from "./types";
+import { Faction, CastleCode, PromoteCode } from "./types";
 
 export default class Move {
   readonly from: {
@@ -17,7 +17,7 @@ export default class Move {
   capturedPiece?: string;
   check?: true;
   checkmate?: true;
-  promotion?: string;
+  promotion?: PromoteCode;
   castle?: CastleCode;
   enpassant?: true;
 

--- a/src/piece.ts
+++ b/src/piece.ts
@@ -2,7 +2,7 @@ import Board from "./board";
 import Chess from "./chess";
 import Fen from "./fen";
 import Move from "./move";
-import { CastleCode, Faction } from "./types";
+import { CastleCode, Faction, PromoteCode } from "./types";
 import {
   addIncrement,
   checkBoundaries,
@@ -163,7 +163,12 @@ export class Pawn extends Piece {
     } else {
       target = [this.rank + 1, this.file];
     }
-    if (this.inBoundaries(...target) && this.panelEmpty(...target)) {
+    if (
+      (this.faction === "w" && target[0] === 0) ||
+      (this.faction === "b" && target[0] === 7)
+    ) {
+      this.checkPromotion(...target);
+    } else if (this.inBoundaries(...target) && this.panelEmpty(...target)) {
       this.validateMove(...target);
     }
   }
@@ -183,7 +188,14 @@ export class Pawn extends Piece {
     }
     for (let i = 0; i < targets.length; i++) {
       if (this.inBoundaries(...targets[i]) && this.canCapture(...targets[i])) {
-        this.validateMove(...targets[i]);
+        if (
+          (this.faction === "w" && targets[i][0] === 0) ||
+          (this.faction === "b" && targets[i][0] === 7)
+        ) {
+          this.checkPromotion(...targets[i]);
+        } else {
+          this.validateMove(...targets[i]);
+        }
       }
     }
   }
@@ -204,6 +216,19 @@ export class Pawn extends Piece {
         move.enpassant = true;
         this.checkSimulation(move);
       }
+    }
+  }
+
+  checkPromotion(rank: number, file: number) {
+    const promoteOption: PromoteCode[] = ["Q", "R", "B", "N"];
+    for (let i = 0; i < 4; i++) {
+      const move = this.createMove(rank, file);
+      if (!this.panelEmpty(rank, file)) {
+        move.capture = true;
+        move.capturedPiece = this.boardRef.get(rank, file);
+      }
+      move.promotion = promoteOption[i];
+      this.checkSimulation(move);
     }
   }
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -94,13 +94,39 @@ export default class Player {
 
     const [fr, ff] = [move.from.rank, move.from.file];
 
-    for (const piece of this.pieces) {
+    for (let i = 0; i < this.pieces.length; i++) {
+      const piece = this.pieces[i];
       if (piece.rank === fr && piece.file === ff) {
         piece.move(move);
+        if (move.promotion) {
+          const newPiece = this.createPromotionPiece(move);
+          this.pieces[i] = newPiece;
+        }
         return;
       }
     }
     throw "can't find piece from that rank and file";
+  }
+
+  createPromotionPiece(move: Move) {
+    if (!move.promotion || !move.faction)
+      throw "move should have promotion and faction prop!";
+    const args: [Faction, number, number, Chess] = [
+      move.faction,
+      move.to.rank,
+      move.to.file,
+      this.chessRef,
+    ];
+    switch (move.promotion) {
+      case "Q":
+        return new Queen(...args);
+      case "R":
+        return new Rook(...args);
+      case "B":
+        return new Bishop(...args);
+      case "N":
+        return new Knight(...args);
+    }
   }
 
   castle(code: CastleCode) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,3 +20,5 @@ type AtoH = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h";
 type OneToEight = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
 export type Notation = `${AtoH}${OneToEight}`;
+
+export type PromoteCode = "Q" | "R" | "B" | "N";

--- a/test.js
+++ b/test.js
@@ -1,47 +1,11 @@
 const Chess = require("./index");
 
-const c = new Chess();
-
-// c.play("e4");
-// c.play("d5");
-// c.play("Qh5");
-// c.play("c6");
-// c.play("f3");
-// c.play("b6");
-// c.play("g3");
-// c.play("e6");
-// c.play("h3");
-// c.play("c5");
-// c.play("a3");
-// c.play("b5");
-// c.play("b3");
-// c.play("a5");
-// c.play("c3");
-// c.play("e5");
-// c.play("d3");
-// c.play("h6");
-// c.play("Qg4");
-// c.play("f6");
-// c.play("Qf4");
-// c.play("exf4");
-// c.play("gxf4");
-// c.play("dxe4");
-// c.play("Be3");
-// c.play("c4");
-// c.play("Ne2");
-// c.play("cxb3");
-// c.play("Nd4");
-// c.play("Nc6");
-// c.play("Nxc6");
-// c.play("Qb6");
-// c.play("Bxb6");
-// c.play("Bxh3");
-// c.play("Bxh3");
-// c.play("Bxa3");
-// c.play("Rxa3");
-// c.play("exd3");
-// c.play("Nd2");
+const c = new Chess(
+  "rnbk2nr/ppp2Ppp/8/3q4/3b2Q1/P7/1PPP1PPP/RNB1KBNR w KQ - 1 7"
+);
 
 c.info();
 
-// const c = new Chess("4k1nr/r5p1/1BN2p1p/pp6/5P2/RpPp1P1B/3N4/4K2R w k - 2 21");
+c.play("fxg8=R+");
+
+c.info();


### PR DESCRIPTION
Create pawn promotion logic. When a pawn legally moves into its promotion rank, we will generate 4 moves instead of one normal move. Each of those 4 moves have the same from & to property, and the only thing that differs them from each other is the promotion property ('Q'/'R'/'B'/N').

Example, test log:
```

rnbk2nr/ppp2Ppp/8/3q4/3b2Q1/P7/1PPP1PPP/RNB1KBNR w KQ - 1 7
r n b k . . n r 
p p p . . P p p 
. . . . . . . . 
. . . q . . . . 
. . . b . . Q . 
P . . . . . . . 
. P P P . P P P 
R N B . K B N R 

status: normal
White to move
Possible moves:
f8=Q+, f8=R+, f8=B, f8=N, fxg8=Q+, fxg8=R+, fxg8=B, fxg8=N, Qf5, Qe6, Qd7+, Qxc8+, Qg5+, Qg6, Qxg7, Qh5, Qf4, Qe4, Qxd4, Qh4+, Qf3, Qe2, Qd1, Qg3, Qh3, a4, b4, b3, c4, c3, d3, f4, f3, g3, h4, h3, Ra2, Nc3, Ke2, Kd1, Be2, Bd3, Bc4, Bb5, Ba6, Nh3, Nf3, Ne2

```
Side note: 
- during implementing this I noticed that the code has gotten a lot messier. Will need to clean and refactor them after this.
- You might have also noticed that the possible pawn move from the example test f8=Q+ should be f8=Q# (checkmate) instead of just normal check. The game will still end after we play f8=Q+, but it will be even better if we can get the notation right. (another todos)